### PR TITLE
Minor improvements to the c18n section

### DIFF
--- a/src/c18n/README.md
+++ b/src/c18n/README.md
@@ -8,7 +8,7 @@ capabilities to resources (global variables, APIs) declared in their ELF
 linkage.
 
 The adversary model for these compartments is one of trusted code, but
-untrustworthy execution: A library such as `libpng` or `libjpeg` is trusted
+untrustworthy execution: a library such as `libpng` or `libjpeg` is trusted
 until it begins dynamic execution -- and has potentially been exposed to
 maligious data.
 With library compartmentalization, an adversary who achieves arbitrary code
@@ -25,12 +25,18 @@ sharing between callers and callees across library boundaries when passing
 variadic argument lists.
 This modified ABI is now used by all CheriABI binaries in CheriBSD, and so
 off-the-shelf aarch64c binaries and libraries can be used with library
-compartmentalization without recompilation to a modified ABI.
+compartmentalization without recompilation to the modified ABI.
 More information on library compartmentalization can be found in the c18n(3)
 man page:
 
 ```
 man c18n
+```
+
+This activity involves source code in the `temporal` subdirectory:
+
+```
+cd ~/tutorial/src/c18n
 ```
 
 ## Compiling applications for library compartmentalization
@@ -65,7 +71,7 @@ Run the program under ktrace with the `-tu` argument to capture only those
 records (and not a full system-call trace):
 
 ```
-ktrace -tu ./helloworld
+env LD_C18N_UTRACE_COMPARTMENT=1 ktrace -tu ./helloworld
 ```
 
 The resulting `ktrace.out` file can be viewed using the kdump(1) command:
@@ -87,7 +93,7 @@ We have constructed a simple application consisting of three C files:
  * `main.c` calls `getpassword()` followed by `passwordcheck()`, and if it
    succeeds, will print the global variable `secret`.
 
-Compile the three C files as a cheriabi binary, `check.cheriabi`:
+Compile the three C files as a CheriABI binary, `check.cheriabi`:
 
 ```
 cc -Wall -g -o check.cheriabi main.c io.c passwordcheck.c
@@ -102,7 +108,7 @@ relatively easy to imagine non-memory-safety vulnerabilities in I/O handling,
 which could lead to arbitrary code execution.
 
 To understand the implications of the vulnerability, we can use `objdump` to
-see what data will be visible to a compromisdd main program.
+see what data will be visible to a compromised main program.
 Run `objdump --full-contents` to hexdump the full program binary, whose
 `.text` and `.code` sections include those available to the program at run
 time:
@@ -116,14 +122,15 @@ I/O routine in its own library:
 
 ```
 cc -Wall -shared -g -o libio.so io.c
+```
+```
 cc -Wall -g -o check.c18n main.c passwordcheck.c -Wl,--dynamic-linker=/libexec/ld-elf-c18n.so.1 -L. -lio
 ```
 
 Now run the program:
 
 ```
-export LD_C18N_LIBRARY_PATH=.
-./check.c18n
+env LD_C18N_LIBRARY_PATH=. ./check.c18n
 ```
 
 The program will print its PID, which you can then use as an argument to
@@ -131,6 +138,8 @@ The program will print its PID, which you can then use as an argument to
 value):
 
 ```
-./chericat -d check.c18n.db -p PID
-./chericat -d check.c18n.db -c libio.so
+chericat -f check.c18n.db -p PID
+```
+```
+chericat -f check.c18n.db -c libio.so
 ```


### PR DESCRIPTION
* Mention a directory to enter before executing commands;
* Correct typos;
* Prefer env over export to reduce the number of commands and not to modify the current user environment;
* List commands in separate code blocks to easily copy them;
* chericat renamed -d to -f.